### PR TITLE
Fix path for bootstrap.js

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -569,7 +569,7 @@ if( !function_exists( "wp_bootstrap_theme_js" ) ) {
 
     // This is the full Bootstrap js distribution file. If you only use a few components that require the js files consider loading them individually instead
     wp_register_script( 'bootstrap', 
-      get_template_directory_uri() . '/bower_components/bootstrap/dist/js/bootstrap.js', 
+      get_template_directory_uri() . '/bower_components/bootstrap-sass/assets/javascripts/bootstrap.js', 
       array('jquery'), 
       '1.2' );
 


### PR DESCRIPTION
In case it's needed.  That was the only issue when setting up the environment on my part. If there were any work arounds, I'm open to suggestions. Now that I think of it, I could have bower installed bootstrap and used the original file configuration from the functions.php.... I've run into this issue before and was told it was something to do an error on bower's side... any other info on the matter is greatly appreciated. I don't think it was a major issue but one to address in regards to the setup of the environment.
